### PR TITLE
Added release 1.22.0 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Releem releases
 ---
-Information about releases of the Releem.
+
+Releem 1.22.0, 2025-09-30 ([What's New At Releem | September 2025](https://releem.com/blog/whats-new-at-releem-september-2025))
+- Added Deadlock monitoring. Closed #293
+- Improved installation page for AWS RDS
+- Redesigned weekly reports with extended information about the work done by Releem
+- Fixed AWS Security hub flagged Releem Agent. Closed #415
+- Added tooltips for the Security Check icons on the dashboard. Closed #429
+- Added documentation on how to [Install Releem Agent on EC2 instances](https://docs.releem.com/releem-agent/installation-guides/cloud-managed-aws-rds-automatic-installation). Closed #407
+- Fixed Releem can’t identify that database version was upgraded. Closed #408
+- Improved process of checking that installation was correct. Closed #409
+- Fixed the server does not appear in the portal after starting the agent. Closed #411
+- Fixed unnecessary restarts during the installation process. Closed #413
+- Fixed Parameter links are returning 404. Closed #417
+- Fixed Alerts High CPU utilization are super late. Closed #424
 
 Releem 1.21.6, 2025-07-31 ([What's New At Releem | July 2025](https://releem.com/blog/whats-new-at-releem-july-2025))
 - Added EXPLAIN and Example Query to the Query Analytics. [Learn more](https://releem.com/blog/query-examples-and-explain-added)


### PR DESCRIPTION
Releem 1.22.0, 2025-09-30 ([What's New At Releem | September 2025](https://releem.com/blog/whats-new-at-releem-september-2025))

- Added Deadlock monitoring. Closed #293
- Improved installation page for AWS RDS
- Redesigned weekly reports with extended information about the work done by Releem
- Fixed AWS Security hub flagged Releem Agent. Closed #415
- Added tooltips for the Security Check icons on the dashboard. Closed #429
- Added documentation on how to [Install Releem Agent on EC2 instances](https://docs.releem.com/releem-agent/installation-guides/cloud-managed-aws-rds-automatic-installation). Closed #407
- Fixed Releem can’t identify that database version was upgraded. Closed #408
- Improved process of checking that installation was correct. Closed #409
- Fixed the server does not appear in the portal after starting the agent. Closed #411
- Fixed unnecessary restarts during the installation process. Closed #413
- Fixed Parameter links are returning 404. Closed #417
- Fixed Alerts High CPU utilization are super late. Closed #424