### PR TITLE
fix: support Aurora Serverless v2 Enhanced Monitoring metrics

### DIFF
--- a/metrics/system/awsrdsenhancedmetrics.go
+++ b/metrics/system/awsrdsenhancedmetrics.go
@@ -220,7 +220,7 @@ func (awsrdsenhancedmetrics *AWSRDSEnhancedMetricsGatherer) GetMetrics(metrics *
 		return errors.New("CloudWatchLogs.GetLogEvents No data")
 	}
 
-	osMetrics, err := parseOSMetrics([]byte(*result.Events[0].Message), true)
+	osMetrics, err := parseOSMetrics([]byte(*result.Events[0].Message), false)
 
 	if err != nil {
 		awsrdsenhancedmetrics.logger.Errorf("Failed to parse metrics: %s.", err)


### PR DESCRIPTION
## Problem

When using `INSTANCE_TYPE=aws/rds` with Aurora MySQL Serverless v2, the agent fails with:

```
ERROR: awsrdsenhancedmetrics.go:226: Failed to parse metrics: json: unknown field "serverlessDatabaseCapacity"
```

Aurora Serverless v2 Enhanced Monitoring JSON includes a `serverlessDatabaseCapacity` field (with `min`, `max`, `current` ACU values) that is not present in provisioned Aurora instances. The `parseOSMetrics()` function is called with `disallowUnknownFields=true`, causing Go's `json.Decoder` to reject the entire payload.

## Fix

Change the `parseOSMetrics()` call at line 223 from strict (`true`) to lenient (`false`) parsing. The function already has the `disallowUnknownFields` parameter designed for this toggle.

```diff
- osMetrics, err := parseOSMetrics([]byte(*result.Events[0].Message), true)
+ osMetrics, err := parseOSMetrics([]byte(*result.Events[0].Message), false)
```

This also future-proofs the agent against any new fields AWS may add to Enhanced Monitoring JSON.

## Environment

- Aurora MySQL Serverless v2 (8.0.mysql_aurora.3.12.0)
- Releem Agent v1.23.4
- `INSTANCE_TYPE=aws/rds`, `AWS_REGION=us-west-2`
- Enhanced Monitoring enabled (60s interval)

## Related

- Discussion: https://github.com/Releem/mysqlconfigurer/discussions/477